### PR TITLE
chore: add assign-issue workflow

### DIFF
--- a/.github/workflows/assign-issue.yml
+++ b/.github/workflows/assign-issue.yml
@@ -1,0 +1,18 @@
+name: Assign Issue
+
+on:
+    issues:
+        types: [opened]
+
+jobs:
+    auto-assign:
+        runs-on: ubuntu-latest
+        permissions:
+            issues: write
+        steps:
+            - name: "Auto-assign issue"
+              uses: pozil/auto-assign-issue@v2
+              with:
+                  assignees: chizmeeple
+                  numOfAssignee: 1
+                  allowSelfAssign: false


### PR DESCRIPTION
Automatically assign issues to myself so I (hopefully) get notifications for any new ones